### PR TITLE
Fix adding correct amount of concurrent promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ BlueBirdQueue.prototype._dequeue = function() {
     self._working = true;
 
     for (var i = 0; i < self.concurrency; i++) {
-      if (self._queue[i]) {
+      if (self._queue[0]) {
         var promise = self._queue.shift();
         promises.push(typeof promise === 'function' ? promise() : promise);
       }


### PR DESCRIPTION
- The algorithm only added self.concurrency elements to the promises list if there were at least twice as much in the queue
- Now it always adds self.concurrency elements
- This is because _queue.shift() decreases the length of the queue
